### PR TITLE
Add the configure using a property file step. Fix bug where you could…

### DIFF
--- a/html/interactive-guides/microprofile-config/download-from-injection.html
+++ b/html/interactive-guides/microprofile-config/download-from-injection.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<!--
+  Copyright (c) 2017 IBM Corporation and others.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Public License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/legal/epl-v10.html
+ 
+  Contributors:
+      IBM Corporation - initial API and implementation
+-->
+ <html>
+
+<head>
+</head>
+<body>
+    <p style="color: red;">Downloaded music from ftp://music.com/us/download.</p>
+</body>

--- a/js/interactive-guides/microprofile-config/microprofile-config-callback.js
+++ b/js/interactive-guides/microprofile-config/microprofile-config-callback.js
@@ -76,6 +76,9 @@ var microprofileConfigCallBack = (function() {
     };
 
     var __correctEditorError = function(stepName, isSave) {
+        if(stepName === "ConfigurePropsFile"){
+            __addPropToConfigProps(stepName);
+        }
         // correct annotation/method
         if (stepName === "ConfigureAsEnvVar") {
             __addPropToServerEnv(stepName);
@@ -86,6 +89,20 @@ var microprofileConfigCallBack = (function() {
         if (isSave === true) {
             contentManager.saveEditor(stepName);
         }
+    };
+
+    var propsFileConfig = "download-url=ftp://music.com/canada/download";
+    var __checkConfigPropsFile = function(content) {
+        var match = false;
+        try {
+            if(content.match(/\s*download-url=ftp:\/\/music.com\/canada\/download\s*/g)){
+                match = true;
+            }
+        }
+        catch (e) {
+
+        }
+        return match;
     };
 
     /*
@@ -105,6 +122,27 @@ var microprofileConfigCallBack = (function() {
         return match;
     };
 
+    var __listenToEditorForPropConfig = function(editor) {
+        var __showWebBrowser = function() {
+            var stepName = editor.getStepName();
+            var content = contentManager.getEditorContents(stepName);
+            if (__checkConfigPropsFile(content)) {
+                __closeEditorErrorBox(stepName);                                
+                contentManager.showBrowser(stepName, 0);
+                contentManager.addRightSlideClassToBrowser(stepName, 0);
+                var index = contentManager.getCurrentInstructionIndex();
+                if(index === 0){
+                    contentManager.markCurrentInstructionComplete(stepName);
+                    contentManager.updateWithNewInstructionNoMarkComplete(stepName);
+                }                
+            } else {
+                // display error and provide link to fix it
+                __createErrorLinkForCallBack(stepName, true);
+            }
+        };
+        editor.addSaveListener(__showWebBrowser);
+    };
+
     var __listenToEditorForServerEnv = function(editor) {
         var __showWebBrowser = function() {
             var stepName = editor.getStepName();
@@ -113,14 +151,29 @@ var microprofileConfigCallBack = (function() {
                 __closeEditorErrorBox(stepName);
                 contentManager.showBrowser(stepName, 0);
                 contentManager.addRightSlideClassToBrowser(stepName, 0);
-                contentManager.markCurrentInstructionComplete(stepName);
-                contentManager.updateWithNewInstructionNoMarkComplete(stepName);
+
+                var index = contentManager.getCurrentInstructionIndex();  
+                if(index === 0){
+                    contentManager.markCurrentInstructionComplete(stepName);
+                    contentManager.updateWithNewInstructionNoMarkComplete(stepName);
+                }                
             } else {
                 // display error and provide link to fix it
                 __createErrorLinkForCallBack(stepName, true);
             }
         };
         editor.addSaveListener(__showWebBrowser);
+    };
+
+    var __addPropToConfigProps = function() {
+        var stepName = stepContent.getCurrentStepName();
+        // reset content every time property is added through the button so as to clear out any
+        // manual editing
+        __closeEditorErrorBox(stepName);
+        contentManager.resetEditorContents(stepName);
+        var content = contentManager.getEditorContents(stepName);
+
+        contentManager.replaceEditorContents(stepName, 1, 1, propsFileConfig);
     };
 
     var __addPropToServerEnv = function() {     
@@ -138,6 +191,16 @@ var microprofileConfigCallBack = (function() {
             to: 1
         });
         contentManager.markEditorReadOnlyLines(stepName, readOnlyLines);
+    };
+
+    var __listenToBrowserForPropFileConfig = function(webBrowser) {
+        var setBrowserContent = function(currentURL) {
+            webBrowser.setBrowserContent("/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/download-from-properties-file.html");
+            contentManager.markCurrentInstructionComplete(webBrowser.getStepName());
+        }
+        // Cannot use contentManager.hideBrowser as the browser is still going thru initialization 
+        webBrowser.contentRootElement.addClass("hidden");
+        webBrowser.addUpdatedURLListener(setBrowserContent);
     };
 
     var __listenToBrowserForServerEnvConfig = function(webBrowser) {
@@ -175,8 +238,11 @@ var microprofileConfigCallBack = (function() {
     };
 
     return {
+        listenToEditorForPropConfig: __listenToEditorForPropConfig,
         listenToEditorForServerEnv: __listenToEditorForServerEnv,
+        listenToBrowserForPropFileConfig: __listenToBrowserForPropFileConfig,
         listenToBrowserForServerEnvConfig: __listenToBrowserForServerEnvConfig,
+        addPropToConfigProps: __addPropToConfigProps,
         addPropToServerEnvButton: __addPropToServerEnvButton,
         saveServerEnvButton: __saveServerEnvButton,
         serverEnvRefreshBrowserButton: __serverEnvRefreshBrowserButton

--- a/json-guides/microprofile-config.json
+++ b/json-guides/microprofile-config.json
@@ -15,6 +15,35 @@
             ]
         },
         {
+            "name": "ConfigurePropsFile",
+            "title": "Configure using a Properties File",
+            "description": [
+                "In Websphere Liberty, you can provide a properties file as part of your Liberty environment configuration. This properties file lets you specify configuration for overriding injected values.",
+                "",
+                "Add the download-url property to the microprofile-config.properties file to override the injected value of the download-url. The properties file contains settings with a default ordinal of 100 which overrides the injected properties with the same name. If a property appears in more than one source, then the property value from the source with the highest ordinal takes precedence. The download-url property in the microprofile-config.properties will be used because the injected default value is only used when no other config sources are provided."
+            ],
+            "instruction": [
+              "Add the <code>download-url=ftp://music.com/canada/download</code> on line 1 or click <action title='Configure download-url in microprofile-config.properties' onclick=\"microprofileConfigCallBack.addPropToConfigProps(event)\"><b>download-url=ftp://music.com/canada/download</b></action>. Then, click <action title='Save' onclick=\"microprofileConfigCallBack.saveServerEnvButton(event)\"><b>Save</b></action> on the editor menu pane.",
+              "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.serverEnvRefreshBrowserButton(event)\"><b>Refresh</b></action> in the following browser to see that the download-url in the microprofile-config.properties file is used.<br/>"
+            ],
+            "content":[
+              {
+                "displayType":"fileEditor",
+                "fileName": "microprofile-config.properties",
+                "preload": [
+                ],
+                "save": true,
+                "callback": "(function test(editor) {microprofileConfigCallBack.listenToEditorForPropConfig(editor); })"
+              },
+              {
+                "displayType":"webBrowser",
+                "url": "https://music.com/download",
+                "browserContent": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/download-from-injection.html",
+                "callback": "(function test(webBrowser) {microprofileConfigCallBack.listenToBrowserForPropFileConfig(webBrowser); })"
+              }
+            ]
+        },
+        {
             "name": "ConfigureAsEnvVar",
             "title": "Configuring as an Environment Variable",
             "description": [

--- a/json-guides/microprofile-config.json
+++ b/json-guides/microprofile-config.json
@@ -23,7 +23,7 @@
                 "Add the download-url property to the microprofile-config.properties file to override the injected value of the download-url. The properties file contains settings with a default ordinal of 100 which overrides the injected properties with the same name. If a property appears in more than one source, then the property value from the source with the highest ordinal takes precedence. The download-url property in the microprofile-config.properties will be used because the injected default value is only used when no other config sources are provided."
             ],
             "instruction": [
-              "Add the <code>download-url=ftp://music.com/canada/download</code> on line 1 or click <action title='Configure download-url in microprofile-config.properties' onclick=\"microprofileConfigCallBack.addPropToConfigProps(event)\"><b>download-url=ftp://music.com/canada/download</b></action>. Then, click <action title='Save' onclick=\"microprofileConfigCallBack.saveServerEnvButton(event)\"><b>Save</b></action> on the editor menu pane.",
+              "Add the <code>download-url=ftp://music.com/canada/download</code> on line 1 or click <action title='Configure download-url in microprofile-config.properties' onclick=\"microprofileConfigCallBack.addPropToConfigProps(event)\"><b>download-url=ftp://music.com/canada/download</b></action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveServerEnvButton(event)\"><b>Run</b></action> on the editor menu pane.",
               "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.serverEnvRefreshBrowserButton(event)\"><b>Refresh</b></action> in the following browser to see that the download-url in the microprofile-config.properties file is used.<br/>"
             ],
             "content":[
@@ -32,7 +32,7 @@
                 "fileName": "microprofile-config.properties",
                 "preload": [
                 ],
-                "save": true,
+                "save": false,
                 "callback": "(function test(editor) {microprofileConfigCallBack.listenToEditorForPropConfig(editor); })"
               },
               {

--- a/json-guides/microprofile-config.json
+++ b/json-guides/microprofile-config.json
@@ -18,7 +18,7 @@
             "name": "ConfigurePropsFile",
             "title": "Configure using a Properties File",
             "description": [
-                "In Websphere Liberty, you can provide a properties file as part of your Liberty environment configuration. This properties file lets you specify configuration for overriding injected values.",
+                "In Websphere Liberty, you can provide a properties file as part of your packaged application. This properties file lets you specify configuration for overriding injected values.",
                 "",
                 "Add the download-url property to the microprofile-config.properties file to override the injected value of the download-url. The properties file contains settings with a default ordinal of 100 which overrides the injected properties with the same name. If a property appears in more than one source, then the property value from the source with the highest ordinal takes precedence. The download-url property in the microprofile-config.properties will be used because the injected default value is only used when no other config sources are provided."
             ],
@@ -29,7 +29,7 @@
             "content":[
               {
                 "displayType":"fileEditor",
-                "fileName": "microprofile-config.properties",
+                "fileName": "META-INF/microprofile-config.properties",
                 "preload": [
                 ],
                 "save": false,


### PR DESCRIPTION
… save the editor and have it complete a future instruction

This pull request will deliver the config properties step but the tabbed editors will come after that has been implemented.