### PR TITLE
Remove trim from property value.

### DIFF
--- a/js/interactive-guides/microprofile-config/playground-callback.js
+++ b/js/interactive-guides/microprofile-config/playground-callback.js
@@ -111,12 +111,12 @@ var playground = function(){
             var fileContent = contentManager.getTabbedEditorContents(STEP_NAME, filename);
             
             if (fileContent) {
-                var regex = /(^.*?)\s*?[=:]\s?(.*$)/gm; //match lines that contain = or :
+                var regex = /(^.*?)\s*[=:]\s*(.*$)/gm; //match lines that contain = or :
                 var match = null;
                 var ordinal;
                 while ((match = regex.exec(fileContent)) !== null) {
                     var key = match[1].trim();
-                    var value = match[2].trim();
+                    var value = match[2];
                     if (key === 'config_ordinal') {
                         //TODO: what if ordinal has already been set? (multiple config_ordinal keys)
                         ordinal = value;


### PR DESCRIPTION
Keep trailing whitespace after the property value to stay true to properties file format spec.
Regex change to ignore any amount of white space in between the key and value.