### PR TITLE
Change font size in sample web; Add ports to files on ordinal page

### DIFF
--- a/css/interactive-guides/microprofile-config/mpconfig.css
+++ b/css/interactive-guides/microprofile-config/mpconfig.css
@@ -15,7 +15,7 @@
 
 .carSiteTitle {
     text-align: center; 
-    font-size: 18px; 
+    font-size: 16px; 
     background-color: #555; 
     color: white; 
     height: 30px;
@@ -26,6 +26,7 @@
 
 .carsGrid td {
     padding: 5px 10px;
+    font-size: 12px;
 }
 
 .carsGrid td img {

--- a/json-guides/microprofile-config.json
+++ b/json-guides/microprofile-config.json
@@ -429,7 +429,6 @@
                   {
                     "displayType":"fileEditor",
                     "fileName": "META-INF/microprofile-config.properties",
-                    "readonly": false,
                     "save": false,
                     "preload": [
                         "port=9081"
@@ -446,7 +445,7 @@
                     "displayType":"fileEditor",
                     "fileName": "server.env",
                     "preload": [
-                      ""
+                      "port=9082"
                     ],
                     "readonly": true,
                     "save": false
@@ -455,6 +454,7 @@
                     "displayType":"fileEditor",
                     "fileName": "bootstrap.properties",
                     "preload": [
+                        "port=9083"
                      ],
                     "readonly": true,
                     "save": false                 }


### PR DESCRIPTION
Somehow the port settings in the bootstrap.properties and server.env files on the change ordinal page were missing their port settings.   Added them back in.

Lowered the font size of the sample app in the sample browser for the demo today.  Design is working on improving this page.