### PR TITLE
Explain if prop is in more than one properties file on classpath

### DIFF
--- a/json-guides/microprofile-config.json
+++ b/json-guides/microprofile-config.json
@@ -175,7 +175,7 @@
             "name": "ConfigurePropsFile",
             "title": "Configuring with the properties file",
             "description": [
-                "You can provide the <code>/META-INF/microprofile-config.properties</code> file as part of your packaged application. The <code>/META-INF/microprofile-config.properties</code> file may be created in multiple locations, but you must specify these file locations in your classpath.",
+                "You can provide the <code>/META-INF/microprofile-config.properties</code> file as part of your packaged application. The <code>/META-INF/microprofile-config.properties</code> file may be created in multiple locations, but you must specify these file locations in your classpath. The same configuration property should not be specified in multiple <code>/META-INF/microprofile-config.properties</code> files that have the same ordinal value as this would result in an indeterministic property value being returned.",
                 "",
                 "The properties file contains settings with a default ordinal of 100 which overrides the injected default values with the same key, so the <code>port</code> property value in the <code>microprofile-config.properties</code> will be used."
             ],


### PR DESCRIPTION
Emily indicates that 
"If the same property is specified in more than one microprofile-config.properties files, which file supplies the value is undetermined. In practice, the same config property should not occur in more than one microprofile-config.properties. If you want to determine its value, you should override it via system property or environment variables."

So, to the Configuring with a properties file page, add
The same config property should not be specified in multiple /META-INF/microprofile-config.properties files that have the same ordinal value as this would result in an indeterministic property value being returned.