### PR TITLE
Move error msg on inject step down a bit

### DIFF
--- a/js/interactive-guides/microprofile-config/microprofile-config-callback.js
+++ b/js/interactive-guides/microprofile-config/microprofile-config-callback.js
@@ -514,7 +514,7 @@ var microprofileConfigCallBack = (function() {
                 editor.closeEditorErrorBox(stepName);
                 contentManager.markCurrentInstructionComplete(stepName);
                 contentManager.setPodContentWithRightSlide(stepName,
-                    "<p  style='font-size: 13px; margin-top: 0; word-wrap: break-word; line-height: inherit;' >The following exception occurs during application startup because no default value has been set:<br/><br/> <span style='color:red'>[ERROR ] CWWKZ0002E</span>: An exception occurred while starting the application io.openliberty.guides.microprofile.mpconfig." +
+                    "<p  style='font-size: 13px; margin-top: 30px; word-wrap: break-word; line-height: inherit;' >The following exception occurs during application startup because no default value has been set:<br/><br/> <span style='color:red'>[ERROR ] CWWKZ0002E</span>: An exception occurred while starting the application io.openliberty.guides.microprofile.mpconfig." +
                     "The exception message was: com.ibm.ws.container.service.state.StateChangeException:" +
                     "org.jboss.weld.exceptions.DeploymentException: WELD-001408: Unsatisfied dependencies for type Integer with qualifiers @configproperty " +
                     "at injection point [BackedAnnotatedField] @Inject @configproperty private " +


### PR DESCRIPTION
After adding the code to have single editor widgets changed to being a single file in a tabbed editor (issue #95), the error message displayed on the injection step appeared to be displayed to high and looked out of place.  Add a margin to the top of the paragraph introducing the DeploymentException so it appears in a better location.