### PR TITLE
Initial drop of MPConfig multiPane implementation

### DIFF
--- a/css/interactive-guides/microprofile-config/mpconfig.css
+++ b/css/interactive-guides/microprofile-config/mpconfig.css
@@ -13,9 +13,6 @@
   font-size: 12px;
   table-layout: fixed;
   margin-left: 30px;
-  @media (max-width: 570px) {
-    margin-left: 0px;
-  }
 }
 
 .propsTable, .propsTable tr:focus {
@@ -95,18 +92,6 @@
     text-align: center;
 }
 
-#guide_content .codeeditor .CodeMirror {
-    height: 100%;
-}
-
-#guide_content .editorContainer{
-    height: 448px;
-}
-
-#guide_content .teContainer .editorContainer{
-    height: 423px;
-}
-
 .ordinalCardContainer {
     width: 100%;
     height: 130px;
@@ -162,4 +147,8 @@
     top: 5px;
     left: 42%;
 
+}
+
+@media (max-width: 570px) {
+    margin-left: 0px;
 }

--- a/css/interactive-guides/microprofile-config/mpconfig.scss
+++ b/css/interactive-guides/microprofile-config/mpconfig.scss
@@ -12,10 +12,18 @@
   width: 100%;
   font-size: 12px;
   table-layout: fixed;
+  margin-left: 30px;
+  @media (max-width: 570px) {
+    margin-left: 0px;
+  }
 }
 
 .propsTable, .propsTable tr:focus {
   outline: none;
+}
+
+.propsTable tr:nth-of-type(even) {
+    background: #f8f8f7;
 }
 
 .propsTable td {

--- a/html/interactive-guides/microprofile-config/microprofile-config-guide.html
+++ b/html/interactive-guides/microprofile-config/microprofile-config-guide.html
@@ -1,5 +1,5 @@
 ---
-layout: interactive-guide
+layout: iguide-multipane
 title: "Separating configuration from code in microservices"
 description: Learn how to perform static configuration injection using MicroProfile Config.
 tags: ['Interactive', 'MicroProfile', 'microservices', 'Config', '@Inject', '@ConfigProperty', 'ConfigSource']
@@ -37,6 +37,7 @@ js:
 - interactive-guides/terminal/terminal
 - interactive-guides/utils
 - interactive-guides/blueprint
+- interactive-guides/iguide-multipane
 - interactive-guides/microprofile-config/microprofile-config-callback
 - interactive-guides/microprofile-config/microprofile-config-guide
 - interactive-guides/microprofile-config/playground-callback

--- a/html/interactive-guides/microprofile-config/welcome.html
+++ b/html/interactive-guides/microprofile-config/welcome.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<!--
+  Copyright (c) 2017 IBM Corporation and others.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Public License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/legal/epl-v10.html
+ 
+  Contributors:
+      IBM Corporation - initial API and implementation
+-->
+<html>
+<head>
+    <link href="https://fonts.googleapis.com/css?family=Asap:400,500,600" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" href="/guides/iguide-microprofile-config/css/interactive-guides/microprofile-config/mpconfig.css">
+</head>
+<body class="carSite">
+    <img class="carLogo" src="/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/images/img-car.svg" alt="car logo" />
+    <p class="carSiteTitle">Car Inventory</p>    
+</body>
+
+</html>

--- a/js/interactive-guides/microprofile-config/microprofile-config-callback.js
+++ b/js/interactive-guides/microprofile-config/microprofile-config-callback.js
@@ -528,8 +528,6 @@ var microprofileConfigCallBack = (function() {
                 }                
             }
         }
-        // Cannot use contentManager.hideBrowser as the browser is still going thru initialization
-        webBrowser.contentRootElement.addClass("hidden");
         webBrowser.addUpdatedURLListener(setBrowserContent);
     };
 

--- a/js/interactive-guides/microprofile-config/microprofile-config-callback.js
+++ b/js/interactive-guides/microprofile-config/microprofile-config-callback.js
@@ -65,10 +65,10 @@ var microprofileConfigCallBack = (function() {
             var content = contentManager.getTabbedEditorContents(stepName, propsFileName);
             if (__checkConfigPropsFile(content)) {
                 editor.closeEditorErrorBox(stepName);
-                var index = contentManager.getCurrentInstructionIndex();
+                var index = contentManager.getCurrentInstructionIndex(stepName);
                 if(index === 0){
                     contentManager.markCurrentInstructionComplete(stepName);
-                    contentManager.updateWithNewInstructionNoMarkComplete(stepName);
+                    //contentManager.updateWithNewInstructionNoMarkComplete(stepName);
                 }
             } else {
                 // display error and provide link to fix it
@@ -103,10 +103,10 @@ var microprofileConfigCallBack = (function() {
             if (__checkServerEnvContent(content)) {
                 editor.closeEditorErrorBox(stepName);
 
-                var index = contentManager.getCurrentInstructionIndex();
+                var index = contentManager.getCurrentInstructionIndex(stepName);
                 if(index === 0){
                     contentManager.markCurrentInstructionComplete(stepName);
-                    contentManager.updateWithNewInstructionNoMarkComplete(stepName);
+                    //contentManager.updateWithNewInstructionNoMarkComplete(stepName);
                 }
             } else {
                 // display error and provide link to fix it
@@ -123,10 +123,10 @@ var microprofileConfigCallBack = (function() {
             if (__checkSystemPropsContent(content)) {
                 editor.closeEditorErrorBox(stepName);
 
-                var index = contentManager.getCurrentInstructionIndex();
+                var index = contentManager.getCurrentInstructionIndex(stepName);
                 if(index === 0){
                     contentManager.markCurrentInstructionComplete(stepName);
-                    contentManager.updateWithNewInstructionNoMarkComplete(stepName);
+                    //contentManager.updateWithNewInstructionNoMarkComplete(stepName);
                 }
             } else {
                 // display error and provide link to fix it
@@ -146,10 +146,10 @@ var microprofileConfigCallBack = (function() {
             if (__checkConfigOrdinalProp(content)) {
                 editor.closeEditorErrorBox(stepName);
 
-                var index = contentManager.getCurrentInstructionIndex();
+                var index = contentManager.getCurrentInstructionIndex(stepName);
                 if(index === 0){
                     contentManager.markCurrentInstructionComplete(stepName);
-                    contentManager.updateWithNewInstructionNoMarkComplete(stepName);
+                    //contentManager.updateWithNewInstructionNoMarkComplete(stepName);
                 }
             } else {
                 // display error and provide link to fix it
@@ -160,39 +160,45 @@ var microprofileConfigCallBack = (function() {
     };
 
 
-    var __addPropToConfigProps = function() {
-        var stepName = stepContent.getCurrentStepName();
+    var __addPropToConfigProps = function(stepName) {
+        if (stepName === undefined) {
+            stepName = stepContent.getCurrentStepName();
+        }
         // reset content every time property is added through the button so as to clear out any manual editing
         contentManager.resetTabbedEditorContents(stepName, propsFileName);
         contentManager.replaceTabbedEditorContents(stepName, propsFileName, 1, 1, propsFileConfig);
     };
 
-    var __addPropToConfigPropsButton = function(event) {
+    var __addPropToConfigPropsButton = function(event, stepName) {
         if (event.type === "click" ||
            (event.type === "keypress" && (event.which === 13 || event.which === 32))) {
             // Click or 'Enter' or 'Space' key event...
-            __addPropToConfigProps();
+            __addPropToConfigProps(stepName);
         }
     };
 
-    var __addConfigOrdinalToProps = function() {
-        var stepName = stepContent.getCurrentStepName();
+    var __addConfigOrdinalToProps = function(stepName) {
+        if (stepName === undefined) {
+            stepName = stepContent.getCurrentStepName();
+        }
         var configOrdinal = "config_ordinal=500";
         // reset content every time property is added through the button so as to clear out any manual editing
         contentManager.resetTabbedEditorContents(stepName, propsFileName );
         contentManager.replaceTabbedEditorContents(stepName, propsFileName, 2, 2, configOrdinal);
     };
 
-    var __addConfigOrdinalToPropsButton = function(event) {
+    var __addConfigOrdinalToPropsButton = function(event, stepName) {
         if (event.type === "click" ||
            (event.type === "keypress" && (event.which === 13 || event.which === 32))) {
             // Click or 'Enter' or 'Space' key event...
-            __addConfigOrdinalToProps();
+            __addConfigOrdinalToProps(stepName);
         }
     };
 
-    var __addPropToServerEnv = function() {
-        var stepName = stepContent.getCurrentStepName();
+    var __addPropToServerEnv = function(stepName) {
+        if (stepName === undefined) {
+            stepName = stepContent.getCurrentStepName();
+        }
         // reset content every time property is added through the button so as to clear out any manual editing
         contentManager.resetTabbedEditorContents(stepName, serverEnvFileName);
         contentManager.replaceTabbedEditorContents(stepName, serverEnvFileName, 1, 1, serverEnvDownloadUrlConfig);
@@ -200,18 +206,20 @@ var microprofileConfigCallBack = (function() {
 
     var systemPropsFileName = "bootstrap.properties";
     var systemPropsDownloadUrlConfig = "port=9083";
-    var __addPropToSystemProperties = function() {
-        var stepName = stepContent.getCurrentStepName();
+    var __addPropToSystemProperties = function(stepName) {
+        if (stepName === undefined) {
+            stepName = stepContent.getCurrentStepName();
+        }
         // reset content every time property is added through the button so as to clear out any manual editing
         contentManager.resetTabbedEditorContents(stepName, systemPropsFileName);
         contentManager.replaceTabbedEditorContents(stepName, systemPropsFileName, 1, 1, systemPropsDownloadUrlConfig);
     };
 
-    var __addPropToSystemPropertiesButton = function(event) {
+    var __addPropToSystemPropertiesButton = function(event, stepName) {
         if (event.type === "click" ||
            (event.type === "keypress" && (event.which === 13 || event.which === 32))) {
             // Click or 'Enter' or 'Space' key event...
-            __addPropToSystemProperties();
+            __addPropToSystemProperties(stepName);
         }
     };
 
@@ -248,27 +256,32 @@ var microprofileConfigCallBack = (function() {
         webBrowser.addUpdatedURLListener(setBrowserContent);
     };
 
-    var __addPropToServerEnvButton = function(event) {
+    var __addPropToServerEnvButton = function(event, stepName) {
         if (event.type === "click" ||
            (event.type === "keypress" && (event.which === 13 || event.which === 32))) {
             // Click or 'Enter' or 'Space' key event...
-            __addPropToServerEnv();
+            __addPropToServerEnv(stepName);
         }
     };
 
-    var __refreshBrowserButton = function(event) {
+    var __refreshBrowserButton = function(event, stepName) {
         if (event.type === "click" ||
            (event.type === "keypress" && (event.which === 13 || event.which === 32))) {
            // Click or 'Enter' or 'Space' key event...
-           contentManager.refreshBrowser(stepContent.getCurrentStepName());
+           if (stepName === undefined) {
+               stepName = stepContent.getCurrentStepName();
+           }
+           contentManager.refreshBrowser(stepName);
         }
     };
 
-    var __saveTabbedEditorButton = function(event) {
+    var __saveTabbedEditorButton = function(event, stepName) {
         if (event.type === "click" ||
            (event.type === "keypress" && (event.which === 13 || event.which === 32))) {
             // Click or 'Enter' or 'Space' key event...
-            var stepName = stepContent.getCurrentStepName();
+            if (stepName === undefined) {
+                stepName = stepContent.getCurrentStepName();
+            }
             var editorFileName;
             if(stepName === "EnableMPConfig") {
                 editorFileName = "server.xml";
@@ -375,10 +388,10 @@ var microprofileConfigCallBack = (function() {
                 contentManager.showBrowser(stepName, 0);
                 contentManager.addRightSlideClassToBrowser(stepName, 0);
 
-                var index = contentManager.getCurrentInstructionIndex();
+                var index = contentManager.getCurrentInstructionIndex(stepName);
                 if(index === 0){
                     contentManager.markCurrentInstructionComplete(stepName);
-                    contentManager.updateWithNewInstructionNoMarkComplete(stepName);
+                    //contentManager.updateWithNewInstructionNoMarkComplete(stepName);
                 }
             } else {
                 // display error and provide link to fix it
@@ -391,10 +404,11 @@ var microprofileConfigCallBack = (function() {
     var serverXmlFileName = "server.xml";
     var __listenToEditorForFeatureInServerXML = function(editor) {      
       var __saveServerXML = function() {
-        var stepName = stepContent.getCurrentStepName();
+        //var stepName = stepContent.getCurrentStepName();
+        var stepName = editor.getStepName();
         var content = contentManager.getTabbedEditorContents(stepName, serverXmlFileName);
         if (__checkMicroProfileConfigFeatureContent(content)) {
-            var stepName = stepContent.getCurrentStepName();
+            //var stepName = stepContent.getCurrentStepName();
             contentManager.markCurrentInstructionComplete(stepName);
         } else {
             // display error to fix it
@@ -457,36 +471,37 @@ var microprofileConfigCallBack = (function() {
         return isConfigFeatureThere;
     };
 
-    var __addMicroProfileConfigFeatureButton = function(event) {
+    var __addMicroProfileConfigFeatureButton = function(event, stepName) {
       if (event.type === "click" ||
          (event.type === "keypress" && (event.which === 13 || event.which === 32))) {
           // Click or 'Enter' or 'Space' key event...
-          __addMicroProfileConfigFeature();
+          __addMicroProfileConfigFeature(stepName);
       }
     };
 
-    var __addMicroProfileConfigFeature = function() {
-
+    var __addMicroProfileConfigFeature = function(stepName) {
+        if (stepName === undefined) {
+            stepName = stepContent.getCurrentStepName();
+         }
         var ConfigFeature = "      <feature>mpConfig-1.1</feature>";
-        var stepName = stepContent.getCurrentStepName();
         // reset content every time feature is added through the button to clear manual editing
         contentManager.resetTabbedEditorContents(stepName, serverXmlFileName);
         var content = contentManager.getTabbedEditorContents(stepName, serverXmlFileName);
         contentManager.replaceTabbedEditorContents(stepName, serverXmlFileName, 6, 6, ConfigFeature);
     };
 
-    var __addInjectDefaultConfigButton = function(event) {
+    var __addInjectDefaultConfigButton = function(event, stepName) {
         if (event.type === "click" ||
         (event.type === "keypress" && (event.which === 13 || event.which === 32))) {
             // Click or 'Enter' or 'Space' key event...
-            __addInjectDefaultConfigToEditor();
+            __addInjectDefaultConfigToEditor(stepName);
         }
     };
     
     var __addInjectDefaultConfigToEditor = function(stepName) {
         var injectConfig = "    @Inject @ConfigProperty(name=\"port\", \n" +
                            "                            defaultValue=\"9080\")";
-        if (!stepName) {
+        if (stepName === undefined) {
            stepName = stepContent.getCurrentStepName();
         }
         // reset content every time property is added through the button so as to clear out any manual editing
@@ -571,18 +586,18 @@ var microprofileConfigCallBack = (function() {
         return annotationIsThere;
     };
 
-    var __addInjectConfigButton = function(event) {
+    var __addInjectConfigButton = function(event, stepName) {
         if (event.type === "click" ||
         (event.type === "keypress" && (event.which === 13 || event.which === 32))) {
             // Click or 'Enter' or 'Space' key event...
-            __addInjectConfigToEditor();
+            __addInjectConfigToEditor(stepName);
         }
     };
 
     var configEditorFileName = "InventoryConfig.java";
     var __addInjectConfigToEditor = function(stepName) {
         var injectConfig = "    @Inject @ConfigProperty(name=\"port\")";
-        if (!stepName) {
+        if (stepName === undefined) {
            stepName = stepContent.getCurrentStepName();
         }
         // reset content every time property is added through the button so as to clear out any manual editing

--- a/js/interactive-guides/microprofile-config/microprofile-config-guide.js
+++ b/js/interactive-guides/microprofile-config/microprofile-config-guide.js
@@ -10,12 +10,10 @@
  *******************************************************************************/
 $(document).ready(function() {
     var iguideJsonName = "/guides/iguide-microprofile-config/json-guides/microprofile-config.json";
-    // var iguideJsonName = "/guides/iguide-circuit-breaker/json-guides/circuit-breaker.json";
     var iguideContextRoot = "MicroprofileConfig";
-    // var iguideContextRoot = "CircuitBreaker";
 
     jsonGuide.getAGuide(iguideJsonName).done(function() {
       blueprint.create(iguideContextRoot);
-      $(ID.toc_guide_title).hide();
+      //$(ID.toc_guide_title).hide();
     });
   });

--- a/js/interactive-guides/microprofile-config/microprofile-config-guide.js
+++ b/js/interactive-guides/microprofile-config/microprofile-config-guide.js
@@ -14,6 +14,5 @@ $(document).ready(function() {
 
     jsonGuide.getAGuide(iguideJsonName).done(function() {
       blueprint.create(iguideContextRoot);
-      //$(ID.toc_guide_title).hide();
     });
   });

--- a/json-guides/microprofile-config.json
+++ b/json-guides/microprofile-config.json
@@ -122,7 +122,7 @@
                 "Begin by enabling the MicroProfile Config 1.1 feature in your <code>server.xml</code> file. This feature allows you to use the MicroProfile Config API to externalize configuration data."
             ],
             "instruction": [
-              "Add the following element declaration inside the featureManager element of the <code>server.xml</code> file, or click <action tabindex='0' role='button' title='Enable MicroProfile Config' aria-label='Enable MicroProfile Config' onkeypress=\"microprofileConfigCallBack.addMicroProfileConfigFeatureButton(event)\" onclick=\"microprofileConfigCallBack.addMicroProfileConfigFeatureButton(event)\">&lt;feature&gtmpConfig-1.1&lt;/feature&gt;</action>. Then, click <action tabindex='0' role='button' title='Save' aria-label='Save' onkeypress=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\" onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\">Save</action> on the editor menu pane."
+              "Add the following element declaration inside the featureManager element of the <code>server.xml</code> file, or click <action tabindex='0' role='button' title='Enable MicroProfile Config' aria-label='Enable MicroProfile Config' onkeypress=\"microprofileConfigCallBack.addMicroProfileConfigFeatureButton(event, 'EnableMPConfig')\" onclick=\"microprofileConfigCallBack.addMicroProfileConfigFeatureButton(event, 'EnableMPConfig')\">&lt;feature&gtmpConfig-1.1&lt;/feature&gt;</action>. Then, click <action tabindex='0' role='button' title='Save' aria-label='Save' onkeypress=\"microprofileConfigCallBack.saveTabbedEditorButton(event, 'EnableMPConfig')\" onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event, 'EnableMPConfig')\">Save</action> on the editor menu pane."
             ],
             "content":[
                 {   
@@ -182,7 +182,7 @@
                 "You can specify a value in the runtime environment for mandatory configuration properties. Properties are mandatory when the annotation does not specify an optional default value. When the mandatory configuration property value is not found in any of the ConfigSources, a <code>NoSuchElementException</code> is thrown during application startup."
             ],
             "instruction": [
-                "To inject a mandatory <code>port</code> configuration property into the code, add the following <code>@Inject</code> and <code>@ConfigProperty</code> annotations to line 9 before declaring the <code>private int port</code>, or click  <action title='Inject a ConfigProperty' onclick='microprofileConfigCallBack.addInjectConfigButton(event)'>@Inject @ConfigProperty(name=\"port\")</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\">Run</action> on the editor menu pane to see the exception occur."
+                "To inject a mandatory <code>port</code> configuration property into the code, add the following <code>@Inject</code> and <code>@ConfigProperty</code> annotations to line 9 before declaring the <code>private int port</code>, or click  <action title='Inject a ConfigProperty' onclick='microprofileConfigCallBack.addInjectConfigButton(event, \"ConfigureViaInject\")'>@Inject @ConfigProperty(name=\"port\")</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event, 'ConfigureViaInject')\">Run</action> on the editor menu pane to see the exception occur."
             ],
             "content":[
                 {   
@@ -190,6 +190,9 @@
                     "url": "https://mycarvendor.openliberty.io/car-types",
                     "browserContent": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/welcome.html",
                     "enable": false
+                },
+                {
+                    "displayType": "pod"
                 },
                 {
                     "displayType":"tabbedEditor",
@@ -246,7 +249,7 @@
                 "You can specify a default value for a configuration property using the <b>defaultValue</b> parameter in the <code>@ConfigProperty</code> annotation. This value is used when a value is not specified in any MicroProfile Config configuration source."
             ],
             "instruction": [
-                "Change the <code>@ConfigProperty</code> annotation on line 9 to the following code, or click <action title='Provide default value using ConfigProperty annotation' onclick=\"microprofileConfigCallBack.addInjectDefaultConfigButton(event)\">@Inject @ConfigProperty(name=\"port\",\n defaultValue=\"9080\")</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\">Run</action> on the editor menu pane.",
+                "Change the <code>@ConfigProperty</code> annotation on line 9 to the following code, or click <action title='Provide default value using ConfigProperty annotation' onclick=\"microprofileConfigCallBack.addInjectDefaultConfigButton(event, 'InjectWithDefaultValue')\">@Inject @ConfigProperty(name=\"port\",\n defaultValue=\"9080\")</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event, 'InjectWithDefaultValue')\">Run</action> on the editor menu pane.",
                 "Type the following URL into the browser that follows, or click <action title='URL' onclick=\"microprofileConfigCallBack.populateURL(event, 'InjectWithDefaultValue')\">https://mycarvendor.openliberty.io/car-types</action> and then press <action title='Enter' onclick=\"microprofileConfigCallBack.enterButtonURL(event, 'InjectWithDefaultValue')\">Enter</action>. The development port (9080) of the ObtainCarTypes microservice returns the values <code>carA</code> and <code>carB</code>."
             ],
             "content":[
@@ -313,8 +316,8 @@
                 "The properties file contains settings with a default ordinal of 100, which overrides the injected default values with the same key so the <code>port</code> property value in the <code>microprofile-config.properties</code> file is used."
             ],
             "instruction": [
-                "In <code>/META-INF/microprofile-config.properties</code>, add the following on line 1, or click <action title='Configure port in microprofile-config.properties' onclick=\"microprofileConfigCallBack.addPropToConfigPropsButton(event)\">port=9081</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\">Run</action> on the editor menu pane.",
-                "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event)\">Refresh</action> in the following browser to see that the port value in the <code>/META-INF/microprofile-config.properties</code> file is used. The test port (9081) of the ObtainCarTypes microservice returns the values <code>typeA</code>, <code>typeB</code>, and <code>typeC</code>."
+                "In <code>/META-INF/microprofile-config.properties</code>, add the following on line 1, or click <action title='Configure port in microprofile-config.properties' onclick=\"microprofileConfigCallBack.addPropToConfigPropsButton(event, 'ConfigurePropsFile')\">port=9081</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event, 'ConfigurePropsFile')\">Run</action> on the editor menu pane.",
+                "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event, 'ConfigurePropsFile')\">Refresh</action> in the following browser to see that the port value in the <code>/META-INF/microprofile-config.properties</code> file is used. The test port (9081) of the ObtainCarTypes microservice returns the values <code>typeA</code>, <code>typeB</code>, and <code>typeC</code>."
             ],
             "content":[
                 {
@@ -385,8 +388,8 @@
                 "Use the <code>${server.config.dir}/server.env</code> file to configure the <code>port</code> environment variable. The <code>server.env</code> file contains the environment settings with a default ordinal value of 300 which is higher than the default ordinal value of 100 for the <code>/META-INF/microprofile-config.properties</code> file. Thus, the <code>port</code> property value in <code>server.env</code> is used."
             ],
             "instruction": [
-              "In <code>server.env</code>, add the following on line 1, or click <action title='Configure port in server.env' onclick=\"microprofileConfigCallBack.addPropToServerEnvButton(event)\">port=9082</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\">Run</action> on the editor menu pane to save the file and restart the server.",
-              "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event)\">Refresh</b></action> in the following browser to see that the port value in the server.env file is used. The quality assurance port (9082) of the ObtainCarTypes microservice returns the values <code>SUV</code>, <code>Crossover</code>, <code>Coupe</code>, and <code>Truck</code>."
+              "In <code>server.env</code>, add the following on line 1, or click <action title='Configure port in server.env' onclick=\"microprofileConfigCallBack.addPropToServerEnvButton(event, 'ConfigureAsEnvVar')\">port=9082</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event, 'ConfigureAsEnvVar')\">Run</action> on the editor menu pane to save the file and restart the server.",
+              "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event, 'ConfigureAsEnvVar')\">Refresh</b></action> in the following browser to see that the port value in the server.env file is used. The quality assurance port (9082) of the ObtainCarTypes microservice returns the values <code>SUV</code>, <code>Crossover</code>, <code>Coupe</code>, and <code>Truck</code>."
             ],
             "content":[
                 {
@@ -467,8 +470,8 @@
                 "In this example, use the <code>${server.config.dir}/bootstrap.properties</code> file to configure the <code>port</code> system property."
             ],
             "instruction": [
-                "Add the following port value on line 1 of <code>bootstrap.properties</code>, or click <action title='Configure port in System Properties' onclick=\"microprofileConfigCallBack.addPropToSystemPropertiesButton(event)\">port=9083</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\">Run</action> on the editor menu pane to save the file and restart the server.",
-                "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event)\">Refresh</action> in the following browser to see that the port value in the <code>bootstrap.properties</code> file is used. The production port (9083) of the ObtainCarTypes microservice returns values <code>SUV</code>, <code>Crossover</code>, <code>Coupe</code>, <code>Truck</code>, and <code>Convertible</code>."
+                "Add the following port value on line 1 of <code>bootstrap.properties</code>, or click <action title='Configure port in System Properties' onclick=\"microprofileConfigCallBack.addPropToSystemPropertiesButton(event,'ConfigureAsSysProp')\">port=9083</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event, 'ConfigureAsSysProp')\">Run</action> on the editor menu pane to save the file and restart the server.",
+                "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event, 'ConfigureAsSysProp')\">Refresh</action> in the following browser to see that the port value in the <code>bootstrap.properties</code> file is used. The production port (9083) of the ObtainCarTypes microservice returns values <code>SUV</code>, <code>Crossover</code>, <code>Coupe</code>, <code>Truck</code>, and <code>Convertible</code>."
             ],
             "content":[
                 {
@@ -554,8 +557,8 @@
                 "Adding <code>config_ordinal</code> to <code>/META-INF/microprofile-config.properties</code> with a value of 500 increases its ordinal value. The port value from <code>/META-INF/microprofile-config.properties</code> now overrides the port value from <code>bootstrap.properties</code>, which has a default ordinal of 400."
             ],
             "instruction": [
-                "On line 2 of the <code>/META-INF/microprofile-config.properties</code> file add the following, or click <action title='Changing the ordinal of microprofile-config.properties' onclick=\"microprofileConfigCallBack.addConfigOrdinalToPropsButton(event)\">config_ordinal=500</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\">Run</action> on the editor menu pane.",
-                "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event)\">Refresh</action> in the following browser to see that the port value in the <code>/META-INF/microprofile-config.properties</code> file is used instead of the one defined in the <code>bootstrap.properties</code> file. The test port (9081) of the ObtainCarTypes microservice returns the values typeA, typeB, and typeC."
+                "On line 2 of the <code>/META-INF/microprofile-config.properties</code> file add the following, or click <action title='Changing the ordinal of microprofile-config.properties' onclick=\"microprofileConfigCallBack.addConfigOrdinalToPropsButton(event, 'UpdateOrdinal')\">config_ordinal=500</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event, 'UpdateOrdinal')\">Run</action> on the editor menu pane.",
+                "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event, 'UpdateOrdinal')\">Refresh</action> in the following browser to see that the port value in the <code>/META-INF/microprofile-config.properties</code> file is used instead of the one defined in the <code>bootstrap.properties</code> file. The test port (9081) of the ObtainCarTypes microservice returns the values typeA, typeB, and typeC."
             ],
             "content":[
                 {

--- a/json-guides/microprofile-config.json
+++ b/json-guides/microprofile-config.json
@@ -5,6 +5,51 @@
     "duration": "25 minutes",
     "audience": "developer",
     "repo": "https://github.com/OpenLiberty/iguide-microprofile-config",
+    "defaultWidgets": [
+        {   
+            "displayType": "webBrowser",
+            "url": "https://mycarvendor.openliberty.io/car-types",
+            "browserContent": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/welcome.html",
+            "enable": false
+        },
+        {   
+            "displayType": "tabbedEditor",
+            "enable": false,
+            "editorList": [
+            {
+                "displayType": "fileEditor",
+                "fileName": "server.xml",
+                "preload": [
+                    "<?xml version=\"1.0\"?>",
+                    "<server description=\"Sample Liberty server\">",
+                    "   <featureManager>",
+                    "      <feature>cdi-1.2</feature>",
+                    "      <feature>jaxrs-2.0</feature>",
+                    "",
+                    "   </featureManager>",
+                    "   <httpEndpoint host=\"*\" id=\"defaultHttpEndpoint\" httpsPort=\"${default.https.port}\"",
+                    "   httpPort=\"{default.http.port}\"/>",
+                    "</server>"
+                ],
+                "save": true
+            }
+            ]
+        }
+    ],
+    "configWidgets": [
+        {   
+            "displayType": "webBrowser",
+            "height": "300px"
+        },
+        {   
+            "displayType": "pod",
+            "height": "200px"
+        },
+        {
+            "displayType": "tabbedEditor",
+            "height": "400px"
+        }  
+    ],
     "steps": [
         {
             "name": "Intro",
@@ -23,13 +68,8 @@
                     "The API combines configuration values from multiple sources, each known as a <b><i>ConfigSource</b></i>. Each ConfigSource has a specified priority, defined by its <b><i>ordinal</i></b> value. A higher ordinal means that the values taken from this ConfigSource will override values from ConfigSources with a lower ordinal value.",
                     "MicroProfile Config has 3 default ConfigSources:",
                     "<ul><li>All <code>META-INF/microprofile-config.properties</code> found on the class path (default ordinal = 100).</li><li>Environment variables (default ordinal = 300).</li><li>System properties (default ordinal = 400).</li></ul>",
-                    "An optional default value can be specified using Java annotations. The optional default value applies if the application does not find configuration values in any of the ConfigSources. The priority of each ConfigSource and the optional default value is shown in the following diagram:"
-                  ],
-                  "content": [
-                    {
-                      "content": "<div class='ordinalPriorities'><img src='/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/images/ordinalPriorities.svg' alt='Ordinal Priorities'></div>",
-                      "displayType": "pod"
-                    }
+                    "An optional default value can be specified using Java annotations. The optional default value applies if the application does not find configuration values in any of the ConfigSources. The priority of each ConfigSource and the optional default value is shown in the following diagram:",
+                    "<div class='ordinalPriorities'><img src='/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/images/ordinalPriorities.svg' alt='Ordinal Priorities'></div>"
                   ]
                 }
             ]
@@ -41,7 +81,39 @@
                 "Imagine that you're developing and deploying a DisplayCarTypes microservice so that you can display the types of cars that are currently available for purchase from your business. This microservice has a dependency on another microservice called ObtainCarTypes, which provides the currently available list. As you develop your DisplayCarTypes microservice, you need to ensure that it works correctly when it interacts with the ObtainCarTypes microservice. For stability and security reasons, you don't want to test against the production version of ObtainCarTypes during the development pipeline. Instead, you run four instances of the ObtainCarTypes microservice, one for each stage of the devOps pipeline as shown in the following diagram:",
                 "",
                 "<div class=\"devOpsPipeline\"><center><img src=\"/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/images/intro.svg\" alt=\"DisplayCarTypes microservice can connect to one of the ObtainCarTypes instances: Development on port 9080, Test on port 9081, Quality Assurance on port 9082, Production on port 9083\"></center></div>",
-                "As you progress through this guide, you will set a configuration property for the port value to specify which of the four ObtainCarTypes instances the DisplayCarTypes microservice should connect to. "]
+                "As you progress through this guide, you will set a configuration property for the port value to specify which of the four ObtainCarTypes instances the DisplayCarTypes microservice should connect to. "
+            ],
+            "content": [
+                {   
+                    "displayType": "webBrowser",
+                    "url": "https://mycarvendor.openliberty.io/car-types",
+                    "browserContent": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/welcome.html",
+                    "enable": false
+                },
+                {   
+                    "displayType": "tabbedEditor",
+                    "enable": false,
+                    "editorList": [
+                    {
+                        "displayType": "fileEditor",
+                        "fileName": "server.xml",
+                        "preload": [
+                            "<?xml version=\"1.0\"?>",
+                            "<server description=\"Sample Liberty server\">",
+                            "   <featureManager>",
+                            "      <feature>cdi-1.2</feature>",
+                            "      <feature>jaxrs-2.0</feature>",
+                            "",
+                            "   </featureManager>",
+                            "   <httpEndpoint host=\"*\" id=\"defaultHttpEndpoint\" httpsPort=\"${default.https.port}\"",
+                            "   httpPort=\"{default.http.port}\"/>",
+                            "</server>"
+                        ],
+                        "save": true
+                    }
+                    ]
+                }
+            ]
         },
         {
             "name": "EnableMPConfig",
@@ -50,11 +122,18 @@
                 "Begin by enabling the MicroProfile Config 1.1 feature in your <code>server.xml</code> file. This feature allows you to use the MicroProfile Config API to externalize configuration data."
             ],
             "instruction": [
-              "Add the following element declaration inside the featureManager element of the <code>server.xml</code> file, or click <action tabindex='0' role='button' title='Enable MicroProfile Config' aria-label='Enable MicroProfile Config' onkeypress=\"microprofileConfigCallBack.addMicroProfileConfigFeatureButton(event)\" onclick=\"microprofileConfigCallBack.addMicroProfileConfigFeatureButton(event)\"><b>&lt;feature&gtmpConfig-1.1&lt;/feature&gt;</b></action>. Then, click <action tabindex='0' role='button' title='Save' aria-label='Save' onkeypress=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\" onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\"><b>Save</b></action> on the editor menu pane."
+              "Add the following element declaration inside the featureManager element of the <code>server.xml</code> file, or click <action tabindex='0' role='button' title='Enable MicroProfile Config' aria-label='Enable MicroProfile Config' onkeypress=\"microprofileConfigCallBack.addMicroProfileConfigFeatureButton(event)\" onclick=\"microprofileConfigCallBack.addMicroProfileConfigFeatureButton(event)\">&lt;feature&gtmpConfig-1.1&lt;/feature&gt;</action>. Then, click <action tabindex='0' role='button' title='Save' aria-label='Save' onkeypress=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\" onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\">Save</action> on the editor menu pane."
             ],
             "content":[
-              {
+                {   
+                    "displayType": "webBrowser",
+                    "url": "https://mycarvendor.openliberty.io/car-types",
+                    "browserContent": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/welcome.html",
+                    "enable": false
+                },
+                {
                   "displayType":"tabbedEditor",
+                  "active": true,
                   "activeTab": "server.xml",
                   "editorList": [
                     {
@@ -82,6 +161,11 @@
                               "to": "10"
                           }
                         ],
+                        "writable": [
+                            {
+                                "line": "6"
+                            }
+                        ],
                         "save": true,
                         "callback": "(function test(editor) {microprofileConfigCallBack.listenToEditorForFeatureInServerXML(editor); })"
                     }
@@ -98,11 +182,18 @@
                 "You can specify a value in the runtime environment for mandatory configuration properties. Properties are mandatory when the annotation does not specify an optional default value. When the mandatory configuration property value is not found in any of the ConfigSources, a <code>NoSuchElementException</code> is thrown during application startup."
             ],
             "instruction": [
-                "To inject a mandatory <code>port</code> configuration property into the code, add the following <code>@Inject</code> and <code>@ConfigProperty</code> annotations to line 9 before declaring the <code>private int port</code>, or click  <action title='Inject a ConfigProperty' onclick='microprofileConfigCallBack.addInjectConfigButton(event)'><b>@Inject @ConfigProperty(name=\"port\")</b></action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\"><b>Run</b></action> on the editor menu pane to see the exception occur."
+                "To inject a mandatory <code>port</code> configuration property into the code, add the following <code>@Inject</code> and <code>@ConfigProperty</code> annotations to line 9 before declaring the <code>private int port</code>, or click  <action title='Inject a ConfigProperty' onclick='microprofileConfigCallBack.addInjectConfigButton(event)'>@Inject @ConfigProperty(name=\"port\")</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\">Run</action> on the editor menu pane to see the exception occur."
             ],
             "content":[
+                {   
+                    "displayType": "webBrowser",
+                    "url": "https://mycarvendor.openliberty.io/car-types",
+                    "browserContent": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/welcome.html",
+                    "enable": false
+                },
                 {
                     "displayType":"tabbedEditor",
+                    "active": true,
                     "activeTab": "InventoryConfig.java",
                     "editorList": [
                         {
@@ -135,13 +226,15 @@
                                     "to": "15"
                                 }
                             ],
+                            "writable": [
+                                {
+                                    "line": "9"
+                                }
+                            ],
                             "save": false,
                             "callback": "(function test(editor) {microprofileConfigCallBack.listenToEditorForInjectConfig(editor); })"
                         }
                     ]
-                },
-                {
-                    "displayType":"pod"
                 }
             ]
         },
@@ -153,12 +246,20 @@
                 "You can specify a default value for a configuration property using the <b>defaultValue</b> parameter in the <code>@ConfigProperty</code> annotation. This value is used when a value is not specified in any MicroProfile Config configuration source."
             ],
             "instruction": [
-                "Change the <code>@ConfigProperty</code> annotation on line 9 to the following code, or click <action title='Provide default value using ConfigProperty annotation' onclick=\"microprofileConfigCallBack.addInjectDefaultConfigButton(event)\"><b>@Inject @ConfigProperty(name=\"port\",\n defaultValue=\"9080\")</b></action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\"><b>Run</b></action> on the editor menu pane.",
-                "Type the following URL into the browser that follows, or click <action title='URL' onclick=\"microprofileConfigCallBack.populateURL(event, 'InjectWithDefaultValue')\"><b>https://mycarvendor.openliberty.io/car-types</b></action> and then press <action title='Enter' onclick=\"microprofileConfigCallBack.enterButtonURL(event, 'InjectWithDefaultValue')\"><b>Enter</b></action>. The development port (9080) of the ObtainCarTypes microservice returns the values <code>carA</code> and <code>carB</code>."
+                "Change the <code>@ConfigProperty</code> annotation on line 9 to the following code, or click <action title='Provide default value using ConfigProperty annotation' onclick=\"microprofileConfigCallBack.addInjectDefaultConfigButton(event)\">@Inject @ConfigProperty(name=\"port\",\n defaultValue=\"9080\")</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\">Run</action> on the editor menu pane.",
+                "Type the following URL into the browser that follows, or click <action title='URL' onclick=\"microprofileConfigCallBack.populateURL(event, 'InjectWithDefaultValue')\">https://mycarvendor.openliberty.io/car-types</action> and then press <action title='Enter' onclick=\"microprofileConfigCallBack.enterButtonURL(event, 'InjectWithDefaultValue')\">Enter</action>. The development port (9080) of the ObtainCarTypes microservice returns the values <code>carA</code> and <code>carB</code>."
             ],
             "content":[
                 {
+                    "displayType":"webBrowser",
+                    "url": "",
+                    "browserContent": "",
+                    "callback": "(function test(webBrowser) {microprofileConfigCallBack.listenToBrowserForInjectDefaultConfig(webBrowser); })",
+                    "enable": true
+                },
+                {
                     "displayType":"tabbedEditor",
+                    "active": true,
                     "activeTab": "InventoryConfig.java",
                     "editorList": [
                         {
@@ -191,16 +292,15 @@
                                     "to": "15"
                                }
                             ],
+                            "writable": [
+                                {
+                                    "line": "9"
+                                }
+                            ],
                             "save": false,
                             "callback": "(function test(editor) {microprofileConfigCallBack.listenToEditorForInjectDefaultConfig(editor); })"
                         }
                     ]                    
-                },
-                {
-                    "displayType":"webBrowser",
-                    "url": "",
-                    "browserContent": "",
-                    "callback": "(function test(webBrowser) {microprofileConfigCallBack.listenToBrowserForInjectDefaultConfig(webBrowser); })"
                 }
             ]
         },
@@ -213,12 +313,20 @@
                 "The properties file contains settings with a default ordinal of 100, which overrides the injected default values with the same key so the <code>port</code> property value in the <code>microprofile-config.properties</code> file is used."
             ],
             "instruction": [
-                "In <code>/META-INF/microprofile-config.properties</code>, add the following on line 1, or click <action title='Configure port in microprofile-config.properties' onclick=\"microprofileConfigCallBack.addPropToConfigPropsButton(event)\"><b>port=9081</b></action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\"><b>Run</b></action> on the editor menu pane.",
-                "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event)\"><b>Refresh</b></action> in the following browser to see that the port value in the <code>/META-INF/microprofile-config.properties</code> file is used. The test port (9081) of the ObtainCarTypes microservice returns the values <code>typeA</code>, <code>typeB</code>, and <code>typeC</code>."
+                "In <code>/META-INF/microprofile-config.properties</code>, add the following on line 1, or click <action title='Configure port in microprofile-config.properties' onclick=\"microprofileConfigCallBack.addPropToConfigPropsButton(event)\">port=9081</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\">Run</action> on the editor menu pane.",
+                "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event)\">Refresh</action> in the following browser to see that the port value in the <code>/META-INF/microprofile-config.properties</code> file is used. The test port (9081) of the ObtainCarTypes microservice returns the values <code>typeA</code>, <code>typeB</code>, and <code>typeC</code>."
             ],
             "content":[
                 {
+                    "displayType":"webBrowser",
+                    "url": "https://mycarvendor.openliberty.io/car-types",
+                    "browserContent": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/download-from-injection.html",
+                    "statusBarText": "Retrieved data from Development on port 9080.",
+                    "callback": "(function test(webBrowser) {microprofileConfigCallBack.listenToBrowserForPropFileConfig(webBrowser); })"
+                },
+                {
                     "displayType": "tabbedEditor",
+                    "active": true,
                     "activeTab": "META-INF/microprofile-config.properties",
                     "callback": "(function test(tabbedEditor) {microprofileConfigCallBack.listenToEditorTabChange(tabbedEditor, 0, 'META-INF/microprofile-config.properties'); })",
                     "editorList": [
@@ -255,17 +363,15 @@
                         "preload": [
                             ""
                         ],
+                        "writable": [
+                            {
+                                "line": "1"
+                            }
+                        ],
                         "callback": "(function test(editor) {microprofileConfigCallBack.listenToEditorForPropConfig(editor); })"
                       }
                     ]
-              },
-              {
-                "displayType":"webBrowser",
-                "url": "https://mycarvendor.openliberty.io/car-types",
-                "browserContent": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/download-from-injection.html",
-                "statusBarText": "Retrieved data from Development on port 9080.",
-                "callback": "(function test(webBrowser) {microprofileConfigCallBack.listenToBrowserForPropFileConfig(webBrowser); })"
-              }
+                }
             ]
         },
         {
@@ -279,12 +385,20 @@
                 "Use the <code>${server.config.dir}/server.env</code> file to configure the <code>port</code> environment variable. The <code>server.env</code> file contains the environment settings with a default ordinal value of 300 which is higher than the default ordinal value of 100 for the <code>/META-INF/microprofile-config.properties</code> file. Thus, the <code>port</code> property value in <code>server.env</code> is used."
             ],
             "instruction": [
-              "In <code>server.env</code>, add the following on line 1, or click <action title='Configure port in server.env' onclick=\"microprofileConfigCallBack.addPropToServerEnvButton(event)\"><b>port=9082</b></action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\"><b>Run</b></action> on the editor menu pane to save the file and restart the server.",
-              "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event)\"><b>Refresh</b></action> in the following browser to see that the port value in the server.env file is used. The quality assurance port (9082) of the ObtainCarTypes microservice returns the values <code>SUV</code>, <code>Crossover</code>, <code>Coupe</code>, and <code>Truck</code>."
+              "In <code>server.env</code>, add the following on line 1, or click <action title='Configure port in server.env' onclick=\"microprofileConfigCallBack.addPropToServerEnvButton(event)\">port=9082</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\">Run</action> on the editor menu pane to save the file and restart the server.",
+              "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event)\">Refresh</b></action> in the following browser to see that the port value in the server.env file is used. The quality assurance port (9082) of the ObtainCarTypes microservice returns the values <code>SUV</code>, <code>Crossover</code>, <code>Coupe</code>, and <code>Truck</code>."
             ],
             "content":[
+                {
+                    "displayType":"webBrowser",
+                    "url": "https://mycarvendor.openliberty.io/car-types",
+                    "browserContent": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/download-from-properties-file.html",
+                    "statusBarText": "Retrieved data from Test on port 9081.",
+                    "callback": "(function test(webBrowser) {microprofileConfigCallBack.listenToBrowserForServerEnvConfig(webBrowser); })"
+                },
               {
                 "displayType": "tabbedEditor",
+                "active": true,
                 "activeTab": "server.env",
                 "callback": "(function test(tabbedEditor) {microprofileConfigCallBack.listenToEditorTabChange(tabbedEditor, 0, 'server.env'); })",
                 "editorList": [
@@ -328,23 +442,15 @@
                     "preload": [
                       ""
                     ],
-                    "readonly": [
-                      {
-                        "from": "1",
-                        "to": "1"
-                      }
+                    "writable": [
+                        {
+                            "line": "1"
+                        }
                     ],
                     "save": false,
                     "callback": "(function test(editor) {microprofileConfigCallBack.listenToEditorForServerEnv(editor); })"
                   }
                 ]
-              },
-              {
-                "displayType":"webBrowser",
-                "url": "https://mycarvendor.openliberty.io/car-types",
-                "browserContent": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/download-from-properties-file.html",
-                "statusBarText": "Retrieved data from Test on port 9081.",
-                "callback": "(function test(webBrowser) {microprofileConfigCallBack.listenToBrowserForServerEnvConfig(webBrowser); })"
               }
             ]
         },
@@ -361,12 +467,20 @@
                 "In this example, use the <code>${server.config.dir}/bootstrap.properties</code> file to configure the <code>port</code> system property."
             ],
             "instruction": [
-                "Add the following port value on line 1 of <code>bootstrap.properties</code>, or click <action title='Configure port in System Properties' onclick=\"microprofileConfigCallBack.addPropToSystemPropertiesButton(event)\"><b>port=9083</b></action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\"><b>Run</b></action> on the editor menu pane to save the file and restart the server.",
-                "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event)\"><b>Refresh</b></action> in the following browser to see that the port value in the <code>bootstrap.properties</code> file is used. The production port (9083) of the ObtainCarTypes microservice returns values <code>SUV</code>, <code>Crossover</code>, <code>Coupe</code>, <code>Truck</code>, and <code>Convertible</code>."
+                "Add the following port value on line 1 of <code>bootstrap.properties</code>, or click <action title='Configure port in System Properties' onclick=\"microprofileConfigCallBack.addPropToSystemPropertiesButton(event)\">port=9083</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\">Run</action> on the editor menu pane to save the file and restart the server.",
+                "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event)\">Refresh</action> in the following browser to see that the port value in the <code>bootstrap.properties</code> file is used. The production port (9083) of the ObtainCarTypes microservice returns values <code>SUV</code>, <code>Crossover</code>, <code>Coupe</code>, <code>Truck</code>, and <code>Convertible</code>."
             ],
             "content":[
                 {
+                    "displayType":"webBrowser",
+                    "url": "https://mycarvendor.openliberty.io/car-types",
+                    "browserContent": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/download-from-property-in-server-env.html",
+                    "statusBarText": "Retrieved data from Quality Assurance on port 9082.",
+                    "callback": "(function test(webBrowser) {microprofileConfigCallBack.listenToBrowserForSystemPropConfig(webBrowser); })"
+                },
+                {
                   "displayType": "tabbedEditor",
+                  "active": true,
                   "activeTab": "bootstrap.properties",
                   "callback": "(function test(tabbedEditor) {microprofileConfigCallBack.listenToEditorTabChange(tabbedEditor, 0, 'bootstrap.properties'); })",
                   "editorList": [
@@ -419,23 +533,15 @@
                         "preload": [
                               ""
                         ],
-                        "readonly": [
+                        "writable": [
                             {
-                                "from": "1",
-                                "to": "5"
+                                "line": "1"
                             }
                         ],
                         "save": false,
                         "callback": "(function test(editor) {microprofileConfigCallBack.listenToEditorForSystemProperties(editor); })"
                     }
                   ]
-                },
-                {
-                  "displayType":"webBrowser",
-                  "url": "https://mycarvendor.openliberty.io/car-types",
-                  "browserContent": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/download-from-property-in-server-env.html",
-                  "statusBarText": "Retrieved data from Quality Assurance on port 9082.",
-                  "callback": "(function test(webBrowser) {microprofileConfigCallBack.listenToBrowserForSystemPropConfig(webBrowser); })"
                 }
             ]
         },
@@ -448,12 +554,20 @@
                 "Adding <code>config_ordinal</code> to <code>/META-INF/microprofile-config.properties</code> with a value of 500 increases its ordinal value. The port value from <code>/META-INF/microprofile-config.properties</code> now overrides the port value from <code>bootstrap.properties</code>, which has a default ordinal of 400."
             ],
             "instruction": [
-                "On line 2 of the <code>/META-INF/microprofile-config.properties</code> file add the following, or click <action title='Changing the ordinal of microprofile-config.properties' onclick=\"microprofileConfigCallBack.addConfigOrdinalToPropsButton(event)\"><b>config_ordinal=500</b></action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\"><b>Run</b></action> on the editor menu pane.",
-                "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event)\"><b>Refresh</b></action> in the following browser to see that the port value in the <code>/META-INF/microprofile-config.properties</code> file is used instead of the one defined in the <code>bootstrap.properties</code> file. The test port (9081) of the ObtainCarTypes microservice returns the values typeA, typeB, and typeC."
+                "On line 2 of the <code>/META-INF/microprofile-config.properties</code> file add the following, or click <action title='Changing the ordinal of microprofile-config.properties' onclick=\"microprofileConfigCallBack.addConfigOrdinalToPropsButton(event)\">config_ordinal=500</action>. Then, click <action title='Run' onclick=\"microprofileConfigCallBack.saveTabbedEditorButton(event)\">Run</action> on the editor menu pane.",
+                "Click <action title='Refresh' onclick=\"microprofileConfigCallBack.refreshBrowserButton(event)\">Refresh</action> in the following browser to see that the port value in the <code>/META-INF/microprofile-config.properties</code> file is used instead of the one defined in the <code>bootstrap.properties</code> file. The test port (9081) of the ObtainCarTypes microservice returns the values typeA, typeB, and typeC."
             ],
             "content":[
+                {
+                    "displayType":"webBrowser",
+                    "url": "https://mycarvendor.openliberty.io/car-types",
+                    "browserContent": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/download-from-property-in-system-props.html",
+                    "statusBarText": "Retrieved data from Production on port 9083.",
+                    "callback": "(function test(webBrowser) {microprofileConfigCallBack.listenToBrowserForPropFileConfig(webBrowser); })"
+                },
               {
                 "displayType": "tabbedEditor",
+                "active": true,
                 "activeTab": "META-INF/microprofile-config.properties",
                 "callback": "(function test(tabbedEditor) {microprofileConfigCallBack.listenToEditorTabChange(tabbedEditor, 0, 'META-INF/microprofile-config.properties'); })",
                 "editorList": [
@@ -487,13 +601,19 @@
                     "fileName": "META-INF/microprofile-config.properties",
                     "save": false,
                     "preload": [
-                        "port=9081"
+                        "port=9081",
+                        ""
                     ],
                     "readonly": [
                       {
                         "from": "1",
                         "to": "1"
                       }
+                    ],
+                    "writable": [
+                        {
+                            "line": "2"
+                        }
                     ],
                     "callback": "(function test(editor) {microprofileConfigCallBack.listenToEditorForOrdinalChange(editor); })"
                   },
@@ -515,13 +635,6 @@
                     "readonly": true,
                     "save": false                 }
                 ]
-              },
-              {
-                "displayType":"webBrowser",
-                "url": "https://mycarvendor.openliberty.io/car-types",
-                "browserContent": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/download-from-property-in-system-props.html",
-                "statusBarText": "Retrieved data from Production on port 9083.",
-                "callback": "(function test(webBrowser) {microprofileConfigCallBack.listenToBrowserForPropFileConfig(webBrowser); })"
               }
             ]
         },
@@ -541,7 +654,21 @@
             ],
             "content": [
                 {
+                    "displayType":"webBrowser",
+                    "url": "https://mycarvendor.openliberty.io/car-types",
+                    "browserContent": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/download-from-property-in-system-props.html",
+                    "statusBarText": "Retrieved data from Production on port 9083.",
+                    "callback": "(function test(webBrowser) {microprofileConfigCallBack.listenToBrowserForPropFileConfig(webBrowser); })",
+                    "enable": false
+                },
+                {
+                    "displayType": "pod",
+                    "content": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/playground.html",
+                    "callback": "(function(pod) {microprofileConfigCallBack.createPlayground(pod, 'DefaultPlayground')})"
+                },
+                {
                     "displayType": "tabbedEditor",
+                    "active": true,
                     "editorList": [
                         {
                             "displayType": "fileEditor",
@@ -602,11 +729,6 @@
                             "save": false
                         }
                     ]
-                },
-                {
-                    "displayType": "pod",
-                    "content": "/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/playground.html",
-                    "callback": "(function(pod) {microprofileConfigCallBack.createPlayground(pod, 'DefaultPlayground')})"
                 }
             ]
         },


### PR DESCRIPTION
This PR covers:
- create a dummy welcome.html to be used in the intro page
- fix up the json with defaultWidgets, configWidgets, remove bold font from instruction, add active /enable/writeable attributes, add stepName to the callback method to fix the single column problem
- microprofile-config-callback.js: remove contentManager.updateWithNewInstructionNoMarkComplete() and pass in stepName to the callback methods so that both single and multi column will work
- update guide html front matter