### PR TITLE
Set focus to browser following 'Run' and during 'Refresh'

### DIFF
--- a/js/interactive-guides/microprofile-config/microprofile-config-callback.js
+++ b/js/interactive-guides/microprofile-config/microprofile-config-callback.js
@@ -67,6 +67,9 @@ var microprofileConfigCallBack = (function() {
                 editor.closeEditorErrorBox(stepName);
                 var index = contentManager.getCurrentInstructionIndex(stepName);
                 if(index === 0){
+                    var stepBrowser = contentManager.getBrowser(stepName);
+                    stepBrowser.contentRootElement.trigger("click");
+    
                     contentManager.markCurrentInstructionComplete(stepName);
                 }
             } else {
@@ -104,6 +107,9 @@ var microprofileConfigCallBack = (function() {
 
                 var index = contentManager.getCurrentInstructionIndex(stepName);
                 if(index === 0){
+                    var stepBrowser = contentManager.getBrowser(stepName);
+                    stepBrowser.contentRootElement.trigger("click");
+    
                     contentManager.markCurrentInstructionComplete(stepName);
                 }
             } else {
@@ -123,6 +129,9 @@ var microprofileConfigCallBack = (function() {
 
                 var index = contentManager.getCurrentInstructionIndex(stepName);
                 if(index === 0){
+                    var stepBrowser = contentManager.getBrowser(stepName);
+                    stepBrowser.contentRootElement.trigger("click");
+    
                     contentManager.markCurrentInstructionComplete(stepName);
                 }
             } else {
@@ -145,6 +154,9 @@ var microprofileConfigCallBack = (function() {
 
                 var index = contentManager.getCurrentInstructionIndex(stepName);
                 if(index === 0){
+                    var stepBrowser = contentManager.getBrowser(stepName);
+                    stepBrowser.contentRootElement.trigger("click");
+    
                     contentManager.markCurrentInstructionComplete(stepName);
                 }
             } else {
@@ -226,6 +238,7 @@ var microprofileConfigCallBack = (function() {
     var __listenToBrowserForPropFileConfig = function(webBrowser) {
         var setBrowserContent = function(currentURL) {
             if (contentManager.getCurrentInstructionIndex(webBrowser.getStepName()) === 1) {
+                webBrowser.contentRootElement.trigger("click");
                 webBrowser.setBrowserContent("/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/download-from-properties-file.html");
                 webBrowser.setBrowserStatusBar("Retrieved data from Test on port 9081.");
                 contentManager.markCurrentInstructionComplete(webBrowser.getStepName());
@@ -237,6 +250,7 @@ var microprofileConfigCallBack = (function() {
     var __listenToBrowserForServerEnvConfig = function(webBrowser) {
         var setBrowserContent = function(currentURL) {
             if (contentManager.getCurrentInstructionIndex(webBrowser.getStepName()) === 1) {
+                webBrowser.contentRootElement.trigger("click");
                 webBrowser.setBrowserContent("/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/download-from-property-in-server-env.html");
                 webBrowser.setBrowserStatusBar("Retrieved data from Quality Assurance on port 9082.");
                 contentManager.markCurrentInstructionComplete(webBrowser.getStepName());
@@ -248,6 +262,7 @@ var microprofileConfigCallBack = (function() {
     var __listenToBrowserForSystemPropConfig = function(webBrowser) {
         var setBrowserContent = function(currentURL) {
             if (contentManager.getCurrentInstructionIndex(webBrowser.getStepName()) === 1) {
+                webBrowser.contentRootElement.trigger("click");
                 webBrowser.setBrowserContent("/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/download-from-property-in-system-props.html");
                 webBrowser.setBrowserStatusBar("Retrieved data from Production on port 9083.");
                 contentManager.markCurrentInstructionComplete(webBrowser.getStepName());
@@ -361,6 +376,9 @@ var microprofileConfigCallBack = (function() {
             var content = contentManager.getTabbedEditorContents(stepName, configEditorFileName);
             if (__checkDefaultInjectionEditorContent(content)) {
                 editor.closeEditorErrorBox(stepName);
+                var stepBrowser = contentManager.getBrowser(stepName);
+                stepBrowser.contentRootElement.trigger("click");
+
                 contentManager.markCurrentInstructionComplete(stepName);
             } else {
                 // display error and provide link to fix it
@@ -493,6 +511,8 @@ var microprofileConfigCallBack = (function() {
 
     var __listenToBrowserForInjectDefaultConfig = function(webBrowser) {
         var setBrowserContent = function(currentURL) {
+            webBrowser.contentRootElement.trigger("click");
+
             // Check if URL is correct before loading content
             if(webBrowser.getURL() === "https://mycarvendor.openliberty.io/car-types"){
                 var instructionIdx = contentManager.getCurrentInstructionIndex(webBrowser.getStepName());


### PR DESCRIPTION
If you have your browser window sized so that it is not tall enough to show a sufficient amount of the sample browser window so that you can see the contents change as the port values change, then it may not be obvious that something has happened when the port value changes.  Therefore, after the user updates a file for a new port value and they select` 'Run'`, add in a click for the browser after the file contents have been successfully validated.   Also, add in a click for the browser as part of each `'Refresh'` button processing to make sure the browser is focused before it refreshes.

** This is how the CB guide works also.