### PR TITLE
Add singleColumnHeight attribute to webBrowser

### DIFF
--- a/css/interactive-guides/microprofile-config/mpconfig.css
+++ b/css/interactive-guides/microprofile-config/mpconfig.css
@@ -55,7 +55,6 @@
 
 .carSite {
     border-top: 3px solid #ffb000;
-    padding-top: 32px;
     text-align: center;
     margin: 0;
     font-family: Asap;
@@ -74,9 +73,18 @@
     font-weight: 500;    
 }
 
+.topFlexContainer {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+    height: 100%;
+}
+
 .flexContainer {
     display: flex;
     flex-wrap: wrap;
+    width: 100%;
 }
 
 .card {

--- a/html/interactive-guides/microprofile-config/download-from-injection.html
+++ b/html/interactive-guides/microprofile-config/download-from-injection.html
@@ -9,7 +9,7 @@
   Contributors:
       IBM Corporation - initial API and implementation
 -->
-<html>
+<html style="height: 100%;">
 <head>
     <link href="https://fonts.googleapis.com/css?family=Asap:400,500,600" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="/guides/iguide-microprofile-config/css/interactive-guides/microprofile-config/mpconfig.css">
@@ -24,7 +24,7 @@
         document.getElementsByTagName('head')[0].appendChild(script);
     </script>  
 </head>
-<body class="carSite">
+<body class="carSite topFlexContainer">
     <img class="carLogo" src="/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/images/img-car.svg" data-externalizedAlt="CAR_LOGO" />
     <p class="carSiteTitle" data-externalizedString="CAR_INVENTORY"></p>
 

--- a/html/interactive-guides/microprofile-config/download-from-properties-file.html
+++ b/html/interactive-guides/microprofile-config/download-from-properties-file.html
@@ -9,7 +9,7 @@
   Contributors:
       IBM Corporation - initial API and implementation
 -->
-<html>
+<html style="height: 100%;">
 <head>
     <link href="https://fonts.googleapis.com/css?family=Asap:400,500,600" rel="stylesheet"> 
     <link rel="stylesheet" type="text/css" href="/guides/iguide-microprofile-config/css/interactive-guides/microprofile-config/mpconfig.css">
@@ -24,7 +24,7 @@
         document.getElementsByTagName('head')[0].appendChild(script);
     </script>  
 </head>
-<body class="carSite">
+<body class="carSite topFlexContainer">
     <img class="carLogo" src="/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/images/img-car.svg" data-externalizedAlt="CAR_LOGO" />
     <p class="carSiteTitle" data-externalizedString="CAR_INVENTORY"></p>
 

--- a/html/interactive-guides/microprofile-config/download-from-property-in-server-env.html
+++ b/html/interactive-guides/microprofile-config/download-from-property-in-server-env.html
@@ -9,7 +9,7 @@
   Contributors:
       IBM Corporation - initial API and implementation
 -->
-<html>
+<html style="height: 100%;">
 <head>
     <link href="https://fonts.googleapis.com/css?family=Asap:400,500,600" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="/guides/iguide-microprofile-config/css/interactive-guides/microprofile-config/mpconfig.css">    
@@ -24,7 +24,7 @@
         document.getElementsByTagName('head')[0].appendChild(script);
     </script>  
 </head>
-<body class="carSite">
+<body class="carSite topFlexContainer">
     <img class="carLogo" src="/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/images/img-car.svg" data-externalizedAlt="CAR_LOGO" />
     <p class="carSiteTitle" data-externalizedString="CAR_INVENTORY"></p>
 

--- a/html/interactive-guides/microprofile-config/download-from-property-in-system-props.html
+++ b/html/interactive-guides/microprofile-config/download-from-property-in-system-props.html
@@ -9,7 +9,7 @@
   Contributors:
       IBM Corporation - initial API and implementation
 -->
-<html>
+<html style="height: 100%;">
 <head>
     <link href="https://fonts.googleapis.com/css?family=Asap:400,500,600" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="/guides/iguide-microprofile-config/css/interactive-guides/microprofile-config/mpconfig.css">
@@ -24,7 +24,7 @@
         document.getElementsByTagName('head')[0].appendChild(script);
     </script>  
 </head>
-<body class="carSite">
+<body class="carSite topFlexContainer">
     <img class="carLogo" src="/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/images/img-car.svg" data-externalizedAlt="CAR_LOGO" />
     <p class="carSiteTitle" data-externalizedString="CAR_INVENTORY"></p>
 

--- a/html/interactive-guides/microprofile-config/welcome.html
+++ b/html/interactive-guides/microprofile-config/welcome.html
@@ -9,7 +9,7 @@
   Contributors:
       IBM Corporation - initial API and implementation
 -->
-<html>
+<html style="height: 100%;">
 <head>
     <link href="https://fonts.googleapis.com/css?family=Asap:400,500,600" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="/guides/iguide-microprofile-config/css/interactive-guides/microprofile-config/mpconfig.css">
@@ -24,9 +24,9 @@
         document.getElementsByTagName('head')[0].appendChild(script);
     </script>  
 </head>
-<body class="carSite" style="padding-top: 60px;">
+<body class="carSite topFlexContainer">
     <img class="carLogo" src="/guides/iguide-microprofile-config/html/interactive-guides/microprofile-config/images/img-car.svg" data-externalizedAlt="CAR_LOGO" />
-    <p class="carSiteTitle" data-externalizedString="CAR_INVENTORY"></p>    
+    <p class="carSiteTitle" data-externalizedString="CAR_INVENTORY"></p>     
 </body>
 
 </html>

--- a/json-guides/microprofile-config.json
+++ b/json-guides/microprofile-config.json
@@ -39,7 +39,8 @@
     "configWidgets": [
         {   
             "displayType": "webBrowser",
-            "height": "300px"
+            "height": "300px",
+            "singleColumnHeight": "450px"
         },
         {   
             "displayType": "pod",


### PR DESCRIPTION
To fully display the various car types in the web browser in a mobile device such as iphone, the browser height has to be different from that of the height used by the multi column view. Add a new "singleColumnHeight" attribute for the webBrowser in the default configWidgets section in the json file. 

Also add an outer flex container to center the web browser contents.