### PR TITLE
Focus file prior to adding code via instruction button

### DIFF
--- a/js/interactive-guides/microprofile-config/microprofile-config-callback.js
+++ b/js/interactive-guides/microprofile-config/microprofile-config-callback.js
@@ -486,6 +486,9 @@ var microprofileConfigCallBack = (function() {
     };
     
     var __addInjectDefaultConfigToEditor = function(stepName) {
+        // Put the BankService.java editor into focus.
+        contentManager.focusTabbedEditorByName(stepName, configEditorFileName);
+
         var injectConfig = "    @Inject @ConfigProperty(name=\"port\", \n" +
                            "                            defaultValue=\"9080\")";
         if (stepName === undefined) {
@@ -588,6 +591,9 @@ var microprofileConfigCallBack = (function() {
 
     var configEditorFileName = "InventoryConfig.java";
     var __addInjectConfigToEditor = function(stepName) {
+        // Put the BankService.java editor into focus.
+        contentManager.focusTabbedEditorByName(stepName, configEditorFileName);
+
         var injectConfig = "    @Inject @ConfigProperty(name=\"port\")";
         if (stepName === undefined) {
            stepName = stepContent.getCurrentStepName();


### PR DESCRIPTION
When selecting the code insertion button in the instructions, make sure that the tabbedEditor is focused and the correct tab for the code being added.