### PR TITLE
Bold 'Run' button reference in playground instruction

### DIFF
--- a/json-guides/microprofile-config.json
+++ b/json-guides/microprofile-config.json
@@ -763,7 +763,7 @@
                 "You can add new properties and override the default ordinal value of the properties files."
             ],
             "instruction": [
-                "Use the editor to inject new properties into the files. Use <code>@Inject @ConfigProperty (name=\"propertyName\");</code> to include the new properties in the <code>InventoryConfig.java</code> file. Use <code>propertyName=propertyValue</code> to add the new properties in any of the properties files. <br><br>Add the <code>config_ordinal</code> property to override the default ordinal value in any of the properties files. <br><br>Click Run to see the file ordinal priority and the property values being used."
+                "Use the editor to inject new properties into the files. Use <code>@Inject @ConfigProperty (name=\"propertyName\");</code> to include the new properties in the <code>InventoryConfig.java</code> file. Use <code>propertyName=propertyValue</code> to add the new properties in any of the properties files. <br><br>Add the <code>config_ordinal</code> property to override the default ordinal value in any of the properties files. <br><br>Click <b>Run</b> to see the file ordinal priority and the property values being used."
               ],
             "content": [                        
                 {


### PR DESCRIPTION
To match other guides, Bold the non-clickable 'Run' reference in the playground instruction.