### PR TITLE
Remove editor error

### DIFF
--- a/js/microprofile-config-callback.js
+++ b/js/microprofile-config-callback.js
@@ -400,6 +400,7 @@ var microprofileConfigCallBack = (function() {
         var stepName = editor.getStepName();
         var content = contentManager.getTabbedEditorContents(stepName, serverXmlFileName);
         if (__checkMicroProfileConfigFeatureContent(content)) {
+            editor.closeEditorErrorBox(stepName);
             editor.addCodeUpdated();
             contentManager.markCurrentInstructionComplete(stepName);
         } else {


### PR DESCRIPTION
On the 'Enabling MicroProfile Config in Open Liberty' step, the error in the editor remains after the code action button in the instruction correctly updates the code in the editor and the user selects 'Run'.

Correct so that the error message is removed.