### PR TITLE
Center error message shown in pod of Inject config step

### DIFF
--- a/js/microprofile-config-callback.js
+++ b/js/microprofile-config-callback.js
@@ -550,10 +550,7 @@ var microprofileConfigCallBack = (function() {
                 // You must indicate to make the "pod" the activeWidget (parameter two) so that 
                 // the code in resizeStepWidgets will un-hide the pod.
                 stepContent.resizeStepWidgets(stepWidgets, "pod", true);
-                contentManager.setPodContentWithSlideUp(stepName,
-                    "<p  class='errorSyntaxCss'>" +  microprofile_config_messages.EXCEPTION1 +  "<span style='color:red'>" + microprofile_config_messages.EXCEPTION2 + " CWMCG5003E</span>" +  microprofile_config_messages.EXCEPTION3 +
-                    "</p>"
-                );
+
                 // Unfortunately, making the pod the active widget allowed our disabled browser
                 // to be full size because of the way the resizeStepWidgets was written.  Therefore,
                 // make the "tabbedEditor" the activeWidget now so that it remains full size since

--- a/js/nls/microprofile-config/messages.js
+++ b/js/nls/microprofile-config/messages.js
@@ -26,8 +26,5 @@ var microprofile_config_messages = {
     CAR_LOGO: "car logo",
     PROPERTY: "Property",
     SOURCE: "Source",
-    VALUE: "Value",
-    EXCEPTION1: "The following exception occurs during application startup because no default value is set:<br><br>", 
-    EXCEPTION2: "[ERROR   ] ",
-    EXCEPTION3: ": The [BackedAnnotatedField] @Inject @ConfigProperty private io.openliberty.guides.mpconfig.InventoryConfig.port InjectionPoint dependency was not resolved. Error: java.util.NoSuchElementException: CWMCG0015E: The property port was not found in the configuration. at com.ibm.ws.microprofile.config.impl.AbstractConfig.getValue(AbstractConfig.java:129) at [internal classes]" 
+    VALUE: "Value"
 } ;

--- a/json-guides/microprofile-config.json
+++ b/json-guides/microprofile-config.json
@@ -163,7 +163,9 @@
                 },
                 {
                     "displayType": "pod",
-                    "hidden": true
+                    "height": "185px",
+                    "hidden": true,
+                    "content": "<p  class='errorSyntaxCss'>The following exception occurs during application startup because no default value is set:<br><br><span style='color:red'>[ERROR&nbsp;&nbsp;] CWMCG5003E</span>: The [BackedAnnotatedField] @Inject @ConfigProperty private io.openliberty.guides.mpconfig.InventoryConfig.port InjectionPoint dependency was not resolved. Error: java.util.NoSuchElementException: CWMCG0015E: The property port was not found in the configuration. at com.ibm.ws.microprofile.config.impl.AbstractConfig.getValue(AbstractConfig.java:129) at [internal classes]</p>"
                 },
                 {
                     "displayType":"tabbedEditor",


### PR DESCRIPTION
On the 'Injecting configuration through @ConfigProperty annotation' step an error panel is slid into view within a pod when 'Run' is selected.  Update so that the pod just shows without sliding in its contents.  Also, center the text so that there isn't a large space underneath the text.